### PR TITLE
Fix OpenAI call temperature

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -68,7 +68,7 @@ def call_ai(epp_content, errors, script_content):
             {"role": "system", "content": "You are an AI assistant."},
             {"role": "user", "content": prompt},
         ],
-        temperature=0,
+        temperature=1,
     )
     return response.choices[0].message.content
 

--- a/validation.py
+++ b/validation.py
@@ -175,7 +175,7 @@ def call_llm(epp_text: str) -> Dict[str, Any]:
         model=MODEL,
         messages=messages,
         response_format={"type": "json_object"},
-        temperature=0
+        temperature=1
     )
     return json.loads(rsp.choices[0].message.content)
 


### PR DESCRIPTION
## Summary
- set `temperature=1` in agent and validation to avoid API errors

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile agent.py validation.py ocr_to_json.py json_to_epp.py`

------
https://chatgpt.com/codex/tasks/task_e_6849c7b0852c833282cdda9667b33f10