### PR TITLE
Fix logging encoding for Windows

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -22,7 +22,7 @@ MAX_ITER = 5
 
 def log(msg):
     os.makedirs(LOG_DIR, exist_ok=True)
-    with open(os.path.join(LOG_DIR, 'agent.log'), 'a') as f:
+    with open(os.path.join(LOG_DIR, 'agent.log'), 'a', encoding='utf-8') as f:
         f.write(f"{datetime.now().isoformat()} {msg}\n")
     print(msg)
 


### PR DESCRIPTION
## Summary
- open the log file with UTF-8 to avoid cp1250 encode errors

## Testing
- `python -m py_compile agent.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849caaa1d908332bf60670a05370476