### PR TITLE
Implement backup during adaptive retry loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Drop JSON files into `invoices_json/` and they will be converted to `.epp`.
 
 The agent validates the output and, if validation fails, asks an OpenAI model for a patch
 to fix the converter. Patched versions of the converter are stored in `script_versions/`.
+Each failing invoice is reprocessed up to three times with these patches applied.
 
 Final valid files are placed in `epp_repaired/`.
 

--- a/agent.py
+++ b/agent.py
@@ -56,6 +56,15 @@ def save_reasoning(base, iteration, text):
     return path
 
 
+def backup_script(iteration: int) -> str:
+    """Save the current converter script before applying a patch."""
+    os.makedirs("script_versions", exist_ok=True)
+    base = Path(SCRIPT).name
+    dst = os.path.join("script_versions", f"{base}_{iteration}_orig")
+    shutil.copy(SCRIPT, dst)
+    return dst
+
+
 
 
 def process_file(json_file):
@@ -93,6 +102,7 @@ def process_file(json_file):
                 f"AI diff saved to {diff_path}\n{diff}"
             )
             if diff:
+                backup_script(iter_no)
                 apply_diff_to_script(diff, Path(SCRIPT), iter_no)
                 import importlib
                 importlib.reload(json_to_epp)


### PR DESCRIPTION
## Summary
- add `backup_script()` helper to store converter before patching
- call helper when validation fails so each iteration saves script state
- mention retry logic in README

## Testing
- `python -m py_compile agent.py validation.py json_to_epp.py openai_config.py ocr_to_json.py`

------
https://chatgpt.com/codex/tasks/task_e_684af940d8ac8332a1fe0f95d9f53b2e