### PR TITLE
Add prompt logging

### DIFF
--- a/openai_config.py
+++ b/openai_config.py
@@ -1,10 +1,16 @@
 import os
+import json
 from pathlib import Path
+from datetime import datetime
 
 try:
     from dotenv import load_dotenv
 except ImportError:  # pragma: no cover - handled via requirements
     load_dotenv = None
+
+
+PROMPT_DIR = Path(__file__).resolve().parent / "logs" / "prompts"
+PROMPT_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def load_api_key() -> None:
@@ -18,3 +24,13 @@ def load_api_key() -> None:
         raise RuntimeError(
             "OPENAI_API_KEY not set. Create a .env file with OPENAI_API_KEY=<your key>"
         )
+
+
+def record_prompt(messages: list[dict], prefix: str = "prompt") -> None:
+    """Print *messages* and save them as JSON under ``logs/prompts``."""
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    path = PROMPT_DIR / f"{prefix}_{ts}.json"
+    path.write_text(json.dumps(messages, ensure_ascii=False, indent=2), encoding="utf-8")
+    print("PROMPT:")
+    print(json.dumps(messages, ensure_ascii=False, indent=2))
+    print(f"Saved prompt to {path}")


### PR DESCRIPTION
## Summary
- print and store model prompts for debugging
- capture prompts from validator and OCR flow

## Testing
- `python -m compileall -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d5edb7e28833286d3f178af8cc99d