### PR TITLE
Fix unsupported temperature in validation

### DIFF
--- a/validation.py
+++ b/validation.py
@@ -190,7 +190,7 @@ def validate_only(epp_text: str) -> dict:
     rsp = client.chat.completions.create(
         model=MODEL,
         response_format={"type": "json_object"},
-        temperature=0.3,
+        temperature=1,
         reasoning_effort="high",
         messages=messages,
     )
@@ -227,7 +227,7 @@ def analyze_epp(epp_text: str, json_text: str, script_code: str) -> dict:
     rsp = client.chat.completions.create(
         model=MODEL,
         response_format={"type": "json_object"},
-        temperature=0.7,
+        temperature=1,
         reasoning_effort="high",
         messages=messages,
     )


### PR DESCRIPTION
## Summary
- set chat temperature to 1 for validation and analysis calls

## Testing
- `pytest -q`
- `python -m py_compile validation.py agent.py ocr_to_json.py json_to_epp.py`

------
https://chatgpt.com/codex/tasks/task_e_684d6306b1d48332beda9628842617f6