### PR TITLE
Add verbose logging of OpenAI prompts and responses

### DIFF
--- a/ocr_to_json.py
+++ b/ocr_to_json.py
@@ -3,7 +3,7 @@ import base64
 from pathlib import Path
 from tqdm import tqdm
 import openai
-from openai_config import load_api_key, record_prompt
+from openai_config import load_api_key, record_prompt, record_response
 
 # Default directories used by the CLI
 DEFAULT_SOURCE_DIR = "invoices"
@@ -56,6 +56,7 @@ IMG_EXTS = (".png", ".jpg", ".jpeg", ".tiff", ".bmp", ".gif", ".webp")
 
 def ocr_image(image_path: str) -> str:
     """Run OCR on *image_path* using an OpenAI vision model."""
+    print(f"\U0001F4F7 OCRing {image_path}")
     with open(image_path, "rb") as fh:
         img_b64 = base64.b64encode(fh.read()).decode()
 
@@ -82,11 +83,13 @@ def ocr_image(image_path: str) -> str:
         reasoning_effort="high",
         messages=messages,
     )
+    record_response(rsp.choices[0].message.content, "ocr_image")
     return rsp.choices[0].message.content
 
 
 def save_invoice_json(img_path: str, out_path: str) -> None:
     """Save extracted fields from *img_path* to *out_path* as JSON."""
+    print(f"\U0001F50E Extracting fields from {img_path}")
     raw_text = ocr_image(img_path)
 
     prompt = (
@@ -109,6 +112,7 @@ def save_invoice_json(img_path: str, out_path: str) -> None:
         reasoning_effort="high",
         messages=messages,
     )
+    record_response(rsp.choices[0].message.content, "ocr_extract")
 
     json_str = rsp.choices[0].message.content.strip()
     with open(out_path, "w", encoding="utf-8") as fh:

--- a/openai_config.py
+++ b/openai_config.py
@@ -10,7 +10,9 @@ except ImportError:  # pragma: no cover - handled via requirements
 
 
 PROMPT_DIR = Path(__file__).resolve().parent / "logs" / "prompts"
+RESPONSE_DIR = Path(__file__).resolve().parent / "logs" / "responses"
 PROMPT_DIR.mkdir(parents=True, exist_ok=True)
+RESPONSE_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def load_api_key() -> None:
@@ -34,3 +36,13 @@ def record_prompt(messages: list[dict], prefix: str = "prompt") -> None:
     print("PROMPT:")
     print(json.dumps(messages, ensure_ascii=False, indent=2))
     print(f"Saved prompt to {path}")
+
+
+def record_response(content: str | None, prefix: str = "response") -> None:
+    """Print *content* and save it under ``logs/responses``."""
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    path = RESPONSE_DIR / f"{prefix}_{ts}.txt"
+    path.write_text(content or "", encoding="utf-8")
+    print("RESPONSE:")
+    print(content)
+    print(f"Saved response to {path}")


### PR DESCRIPTION
## Summary
- expand `openai_config` with a response logger
- log OpenAI interaction prompts and answers in OCR and validation scripts
- print progress messages when running OCR, validation and syntax fixes

## Testing
- `python -m py_compile openai_config.py validation.py ocr_to_json.py agent.py json_to_epp.py`

------
https://chatgpt.com/codex/tasks/task_e_684d7dfda8b08332a82978e663fa599f